### PR TITLE
fix(extension): make frame captures deterministic

### DIFF
--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -46,6 +46,8 @@ import {
 } from './automation-native';
 import {
   buildPreferredCaptureTabIds,
+  hasExplicitCaptureFrameTarget,
+  resolveCaptureFrameTarget,
   shouldRetryGenericCaptureResult,
   type GenericCaptureCommand,
 } from './live-capture-routing';
@@ -368,23 +370,6 @@ function resolveLiveConsoleTabId(value: unknown): number | undefined {
   }
 
   return tabId;
-}
-
-function resolveCaptureFrameId(value: unknown): number | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new Error('frameId must be an integer');
-  }
-
-  const frameId = Math.floor(value);
-  if (!Number.isInteger(frameId) || frameId < 0) {
-    throw new Error('frameId must be an integer');
-  }
-
-  return frameId;
 }
 
 function resolveLiveConsoleSinceTs(value: unknown): number | undefined {
@@ -3143,7 +3128,7 @@ async function sendCaptureCommandToTab(
       throw error;
     }
 
-    const recovered = await ensureContentScriptReady(tabId);
+    const recovered = await ensureContentScriptReady(tabId, frameId ?? 0);
     if (!recovered) {
       throw new Error('Extension target is unavailable after recovery attempt');
     }
@@ -3525,6 +3510,18 @@ async function listTabFrames(tabId: number): Promise<FrameCaptureMetadata[]> {
   return mergeFrameElementMetadata(frames, frameElements);
 }
 
+async function resolveCaptureCommandFrame(
+  tabId: number,
+  payload: Record<string, unknown>,
+): Promise<FrameCaptureMetadata> {
+  if (!hasExplicitCaptureFrameTarget(payload)) {
+    return { frameId: 0 };
+  }
+
+  const frames = await listTabFrames(tabId);
+  return resolveCaptureFrameTarget(frames, payload);
+}
+
 function mergeFramePageStates(
   captures: Array<{ frame: FrameCaptureMetadata; payload: Record<string, unknown>; truncated?: boolean }>,
   maxItems: number,
@@ -3655,16 +3652,13 @@ function classifyFrameCaptureError(frame: FrameCaptureMetadata, error: unknown):
 async function capturePageStateAcrossFrames(
   tabId: number,
   payload: Record<string, unknown>,
+  targetFrame?: FrameCaptureMetadata,
 ): Promise<{ payload: Record<string, unknown>; truncated?: boolean }> {
-  const frames = await listTabFrames(tabId);
+  const frames = targetFrame ? [targetFrame] : await listTabFrames(tabId);
   const maxItems = typeof payload.maxItems === 'number' && Number.isFinite(payload.maxItems)
     ? Math.max(1, Math.floor(payload.maxItems))
     : 40;
   const captures: Array<{ frame: FrameCaptureMetadata; payload: Record<string, unknown>; truncated?: boolean }> = [];
-
-  if (frames.some((frame) => frame.frameId !== 0)) {
-    await injectContentScriptFallback(tabId).catch(() => false);
-  }
 
   for (const frame of frames) {
     try {
@@ -3695,7 +3689,7 @@ async function capturePageStateAcrossFrames(
   }
 
   if (captures.length === 0) {
-    return sendCaptureCommandToTab(tabId, 'CAPTURE_PAGE_STATE', payload);
+    return sendCaptureCommandToTab(tabId, 'CAPTURE_PAGE_STATE', payload, true, 0);
   }
 
   return mergeFramePageStates(captures, maxItems);
@@ -3705,25 +3699,26 @@ async function executeRetriableGenericCapture(
   tabId: number,
   command: GenericCaptureCommand,
   payload: Record<string, unknown>,
-  frameId?: number,
+  frame?: FrameCaptureMetadata,
 ): Promise<{ payload: Record<string, unknown>; truncated?: boolean }> {
-  let capture = command === 'CAPTURE_PAGE_STATE'
-    ? await capturePageStateAcrossFrames(tabId, payload)
-    : await sendCaptureCommandToTab(tabId, command, payload, true, frameId);
+  const captureOnce = (): Promise<{ payload: Record<string, unknown>; truncated?: boolean }> => {
+    return command === 'CAPTURE_PAGE_STATE'
+      ? capturePageStateAcrossFrames(tabId, payload, frame)
+      : sendCaptureCommandToTab(tabId, command, payload, true, frame?.frameId);
+  };
+  let capture = await captureOnce();
 
   if (!shouldRetryGenericCaptureResult(command, capture.payload)) {
     return capture;
   }
 
   await sleep(150);
-  const contentReady = await ensureContentScriptReady(tabId);
+  const contentReady = await ensureContentScriptReady(tabId, frame?.frameId ?? 0);
   if (!contentReady) {
     return capture;
   }
 
-  capture = command === 'CAPTURE_PAGE_STATE'
-    ? await capturePageStateAcrossFrames(tabId, payload)
-    : await sendCaptureCommandToTab(tabId, command, payload, true, frameId);
+  capture = await captureOnce();
 
   return capture;
 }
@@ -4547,6 +4542,10 @@ async function executeCaptureCommand(
     throw new Error(`tabId ${tab.id} is not bound to this session`);
   }
 
+  if (!isUrlAllowed(tab.url ?? '', captureConfig.allowlist)) {
+    throw new Error('Live capture is blocked because the target tab is no longer allowlisted.');
+  }
+
   rememberCaptureTabForSession(context.sessionId, tab);
 
   const tabId = tab.id;
@@ -4579,7 +4578,7 @@ async function executeCaptureCommand(
     const height = Math.floor(rawHeight);
     await updateWindowViewport(tab.windowId, width, height);
     await sleep(150);
-    const metrics = await sendCaptureCommandToTab(tabId, 'CAPTURE_LAYOUT_METRICS', {}, false);
+    const metrics = await sendCaptureCommandToTab(tabId, 'CAPTURE_LAYOUT_METRICS', {}, false, 0);
 
     return {
       payload: {
@@ -4596,7 +4595,10 @@ async function executeCaptureCommand(
   }
 
   if (command === 'CAPTURE_PAGE_STATE') {
-    return executeRetriableGenericCapture(tabId, 'CAPTURE_PAGE_STATE', payload);
+    const frame = hasExplicitCaptureFrameTarget(payload)
+      ? await resolveCaptureCommandFrame(tabId, payload)
+      : undefined;
+    return executeRetriableGenericCapture(tabId, 'CAPTURE_PAGE_STATE', payload, frame);
   }
 
   if (command === 'CAPTURE_UI_SNAPSHOT') {
@@ -4627,7 +4629,7 @@ async function executeCaptureCommand(
       includeStyles,
     };
 
-    const captured = await sendCaptureCommandToTab(tabId, 'CAPTURE_UI_SNAPSHOT', contentPayload);
+    const captured = await sendCaptureCommandToTab(tabId, 'CAPTURE_UI_SNAPSHOT', contentPayload, true, 0);
 
     const basePayload = captured.payload;
     const now = Date.now();
@@ -4753,10 +4755,12 @@ async function executeCaptureCommand(
   }
 
   if (command === 'CAPTURE_DOM_DOCUMENT' || command === 'CAPTURE_DOM_SUBTREE') {
-    return executeRetriableGenericCapture(tabId, command, payload, resolveCaptureFrameId(payload.frameId));
+    const frame = await resolveCaptureCommandFrame(tabId, payload);
+    return executeRetriableGenericCapture(tabId, command, payload, frame);
   }
 
-  return sendCaptureCommandToTab(tabId, command, payload, true, resolveCaptureFrameId(payload.frameId));
+  const frame = await resolveCaptureCommandFrame(tabId, payload);
+  return sendCaptureCommandToTab(tabId, command, payload, true, frame.frameId);
 }
 
 const sessionManager = new SessionManager({
@@ -4892,23 +4896,28 @@ async function getActiveTab(): Promise<chrome.tabs.Tab | undefined> {
   return preferred[0] ?? currentWindowTabs[0];
 }
 
-async function pingContentScript(tabId: number): Promise<boolean> {
+async function pingContentScript(tabId: number, frameId: number = 0): Promise<boolean> {
   return new Promise((resolve) => {
-    chrome.tabs.sendMessage(tabId, { type: 'CAPTURE_PING' }, (response?: CapturePingResponse) => {
-      if (chrome.runtime.lastError) {
-        resolve(false);
-        return;
-      }
+    chrome.tabs.sendMessage(
+      tabId,
+      { type: 'CAPTURE_PING' },
+      { frameId },
+      (response?: CapturePingResponse) => {
+        if (chrome.runtime.lastError) {
+          resolve(false);
+          return;
+        }
 
-      resolve(Boolean(response?.ok));
-    });
+        resolve(Boolean(response?.ok));
+      },
+    );
   });
 }
 
-async function injectContentScriptFallback(tabId: number): Promise<boolean> {
+async function injectContentScriptFallback(tabId: number, frameId: number = 0): Promise<boolean> {
   try {
     await chrome.scripting.executeScript({
-      target: { tabId, allFrames: true },
+      target: { tabId, frameIds: [frameId] },
       files: ['content-script.js'],
       world: 'ISOLATED',
     });
@@ -4922,20 +4931,20 @@ async function injectContentScriptFallback(tabId: number): Promise<boolean> {
   }
 }
 
-async function ensureContentScriptReady(tabId: number): Promise<boolean> {
-  const initial = await pingContentScript(tabId);
+async function ensureContentScriptReady(tabId: number, frameId: number = 0): Promise<boolean> {
+  const initial = await pingContentScript(tabId, frameId);
   if (initial) {
     captureDiagnostics.contentScriptReady = true;
     return true;
   }
 
-  const injected = await injectContentScriptFallback(tabId);
+  const injected = await injectContentScriptFallback(tabId, frameId);
   if (!injected) {
     captureDiagnostics.contentScriptReady = false;
     return false;
   }
 
-  const afterInject = await pingContentScript(tabId);
+  const afterInject = await pingContentScript(tabId, frameId);
   captureDiagnostics.contentScriptReady = afterInject;
   return afterInject;
 }

--- a/apps/chrome-extension/src/live-capture-routing.spec.ts
+++ b/apps/chrome-extension/src/live-capture-routing.spec.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { buildPreferredCaptureTabIds, shouldRetryGenericCaptureResult } from './live-capture-routing';
+import {
+  buildPreferredCaptureTabIds,
+  hasExplicitCaptureFrameTarget,
+  resolveCaptureFrameTarget,
+  shouldRetryGenericCaptureResult,
+} from './live-capture-routing';
 
 describe('live capture routing helpers', () => {
   it('prefers the active tab before remembered and scoped tabs', () => {
@@ -36,5 +41,58 @@ describe('live capture routing helpers', () => {
     expect(shouldRetryGenericCaptureResult('CAPTURE_PAGE_STATE', {
       summary: { buttons: 1, links: 0, inputs: 0, modals: 0 },
     })).toBe(false);
+  });
+});
+
+describe('capture frame targeting', () => {
+  const frames = [
+    { frameId: 0, url: 'https://course.example.com/lecture', sameOriginWithTop: true },
+    {
+      frameId: 181,
+      url: 'https://player.hotmart.com/embed/video',
+      parentUrl: 'https://course.example.com/lecture',
+      sameOriginWithTop: false,
+    },
+    { frameId: 182, url: 'https://m.stripe.network/inner.html', sameOriginWithTop: false },
+    { frameId: 183, url: 'https://js.stripe.com/v3/controller.html', sameOriginWithTop: false },
+  ];
+
+  it('returns top-frame or explicit-frame metadata', () => {
+    expect(hasExplicitCaptureFrameTarget({})).toBe(false);
+    expect(resolveCaptureFrameTarget(frames, {})).toBe(frames[0]);
+    expect(resolveCaptureFrameTarget(frames, { frameId: 181 })).toBe(frames[1]);
+    expect(() => resolveCaptureFrameTarget([], {})).toThrow('No top frame found');
+    expect(() => resolveCaptureFrameTarget(frames, { frameId: 999 })).toThrow(
+      'No frame found for frameId 999',
+    );
+  });
+
+  it('resolves a unique frame URL case-insensitively', () => {
+    expect(hasExplicitCaptureFrameTarget({ frameUrlContains: 'HOTMART' })).toBe(true);
+    expect(resolveCaptureFrameTarget(frames, { frameUrlContains: 'HOTMART' })).toBe(frames[1]);
+  });
+
+  it('checks frameId and frameUrlContains for consistency', () => {
+    expect(resolveCaptureFrameTarget(frames, {
+      frameId: 181,
+      frameUrlContains: 'hotmart.com',
+    })).toBe(frames[1]);
+    expect(() => resolveCaptureFrameTarget(frames, {
+      frameId: 181,
+      frameUrlContains: 'stripe.com',
+    })).toThrow('frameId 181 does not match frameUrlContains "stripe.com"');
+    expect(() => resolveCaptureFrameTarget(frames, {
+      frameId: 999,
+      frameUrlContains: 'hotmart.com',
+    })).toThrow('No frame found for frameId 999');
+  });
+
+  it('rejects missing and ambiguous URL matches', () => {
+    expect(() => resolveCaptureFrameTarget(frames, {
+      frameUrlContains: 'missing.example',
+    })).toThrow('No frame matches frameUrlContains "missing.example"');
+    expect(() => resolveCaptureFrameTarget(frames, {
+      frameUrlContains: 'stripe',
+    })).toThrow('frameUrlContains "stripe" matched 2 frames (182, 183); specify frameId');
   });
 });

--- a/apps/chrome-extension/src/live-capture-routing.ts
+++ b/apps/chrome-extension/src/live-capture-routing.ts
@@ -3,6 +3,16 @@ export type GenericCaptureCommand =
   | 'CAPTURE_DOM_DOCUMENT'
   | 'CAPTURE_PAGE_STATE';
 
+export type CaptureFrameCandidate = {
+  frameId: number;
+  url?: string;
+};
+
+export type CaptureFrameTarget = {
+  frameId?: unknown;
+  frameUrlContains?: unknown;
+};
+
 type CaptureTabPreferenceOptions = {
   activeTabId?: number;
   rememberedTabId?: number;
@@ -61,6 +71,69 @@ function hasFrameCaptureError(frames: unknown): boolean {
   }
 
   return frames.some((frame) => asRecord(frame)?.frameCaptureError === true);
+}
+
+export function hasExplicitCaptureFrameTarget(target: CaptureFrameTarget): boolean {
+  return target.frameId !== undefined || target.frameUrlContains !== undefined;
+}
+
+export function resolveCaptureFrameTarget<T extends CaptureFrameCandidate>(
+  frames: T[],
+  target: CaptureFrameTarget,
+): T {
+  let frameId: number | undefined;
+  if (target.frameId !== undefined) {
+    if (typeof target.frameId !== 'number' || !Number.isInteger(target.frameId) || target.frameId < 0) {
+      throw new Error('frameId must be a non-negative integer');
+    }
+    frameId = target.frameId;
+  }
+
+  let frameUrlContains: string | undefined;
+  if (target.frameUrlContains !== undefined) {
+    if (typeof target.frameUrlContains !== 'string' || target.frameUrlContains.trim().length === 0) {
+      throw new Error('frameUrlContains must be a non-empty string');
+    }
+    frameUrlContains = target.frameUrlContains.trim();
+  }
+
+  if (!frameUrlContains) {
+    const frame = frameId === undefined
+      ? frames.find((candidate) => candidate.frameId === 0)
+      : frames.find((candidate) => candidate.frameId === frameId);
+    if (!frame) {
+      throw new Error(frameId === undefined ? 'No top frame found' : `No frame found for frameId ${frameId}`);
+    }
+    return frame;
+  }
+
+  const normalizedUrl = frameUrlContains.toLowerCase();
+  const candidates = frameId === undefined
+    ? frames
+    : frames.filter((frame) => frame.frameId === frameId);
+  if (frameId !== undefined && candidates.length === 0) {
+    throw new Error(`No frame found for frameId ${frameId}`);
+  }
+
+  const matches = candidates.filter((frame) => frame.url?.toLowerCase().includes(normalizedUrl));
+  if (frameId !== undefined) {
+    if (matches.length === 0) {
+      throw new Error(`frameId ${frameId} does not match frameUrlContains "${frameUrlContains}"`);
+    }
+    return matches[0];
+  }
+
+  if (matches.length === 0) {
+    throw new Error(`No frame matches frameUrlContains "${frameUrlContains}"`);
+  }
+  if (matches.length > 1) {
+    const frameIds = matches.map((frame) => frame.frameId).join(', ');
+    throw new Error(
+      `frameUrlContains "${frameUrlContains}" matched ${matches.length} frames (${frameIds}); specify frameId`,
+    );
+  }
+
+  return matches[0];
 }
 
 export function buildPreferredCaptureTabIds(options: CaptureTabPreferenceOptions): number[] {

--- a/apps/docs/docs/mcp-tools/v2-heavy-capture.md
+++ b/apps/docs/docs/mcp-tools/v2-heavy-capture.md
@@ -2,12 +2,33 @@
 
 Heavy capture is server-orchestrated and extension-executed through command/response messages.
 
+## Frame targeting
+
+Single-document DOM, style, and layout captures default to the top frame (`frameId: 0`). This prevents
+multi-frame pages from returning whichever content-script response happens to arrive first.
+
+Use either `frameId` or a case-insensitive `frameUrlContains` substring to capture a child frame.
+The URL substring must match exactly one frame; zero or multiple matches return an explicit error.
+You can supply both fields to verify that a remembered frame ID still belongs to the expected URL.
+Frame targeting keeps the existing session binding and top-tab allowlist checks.
+
+`get_page_state` and `get_interactive_elements` aggregate all frames when no frame target is
+provided. Passing either targeting field limits the result to one frame.
+For `assert_page_state` and `wait_for_page_state`, `frameUrlContains` remains an item matcher over
+the aggregate page model.
+
 ## `get_dom_subtree`
 
 ```json
 {
   "name": "get_dom_subtree",
-  "arguments": { "sessionId": "sess_123", "selector": "#checkout-form", "maxDepth": 5, "maxBytes": 120000 }
+  "arguments": {
+    "sessionId": "sess_123",
+    "selector": "#checkout-form",
+    "frameUrlContains": "checkout.example.com",
+    "maxDepth": 5,
+    "maxBytes": 120000
+  }
 }
 ```
 
@@ -22,14 +43,26 @@ Heavy capture is server-orchestrated and extension-executed through command/resp
 ```json
 {
   "name": "get_computed_styles",
-  "arguments": { "sessionId": "sess_123", "selector": ".submit-button", "properties": ["display", "visibility", "opacity"] }
+  "arguments": {
+    "sessionId": "sess_123",
+    "selector": ".submit-button",
+    "frameUrlContains": "checkout.example.com",
+    "properties": ["display", "visibility", "opacity"]
+  }
 }
 ```
 
 ## `get_layout_metrics`
 
 ```json
-{ "name": "get_layout_metrics", "arguments": { "sessionId": "sess_123", "selector": ".modal" } }
+{
+  "name": "get_layout_metrics",
+  "arguments": {
+    "sessionId": "sess_123",
+    "selector": ".modal",
+    "frameUrlContains": "checkout.example.com"
+  }
+}
 ```
 
 ## `get_page_state`
@@ -41,6 +74,7 @@ Use this before raw DOM capture when you need a compact page model for buttons, 
   "name": "get_page_state",
   "arguments": {
     "sessionId": "sess_123",
+    "frameId": 0,
     "maxItems": 40,
     "maxTextLength": 80,
     "includeButtons": true,
@@ -67,6 +101,7 @@ Returns compact live refs for interactive elements so later automation can targe
   "name": "get_interactive_elements",
   "arguments": {
     "sessionId": "sess_123",
+    "frameUrlContains": "checkout.example.com",
     "kinds": ["buttons", "inputs", "focused"],
     "maxItems": 20
   }

--- a/apps/e2e-playwright/tests/full.live-automation.spec.ts
+++ b/apps/e2e-playwright/tests/full.live-automation.spec.ts
@@ -632,6 +632,105 @@ test.describe('@full live automation through MCP and extension session', () => {
     }
   });
 
+  test('routes repeated DOM captures deterministically on multi-frame pages', async () => {
+    const port = await getFreePort();
+    mcp = await connectMcpClient(createTempDataDir('bdmcp-e2e-frame-capture-routing-'), {
+      port,
+      env: { MCP_LOOP_GUARD: '0' },
+    });
+
+    extension = await launchExtensionContext();
+    await assertExtensionInstalled(extension.context, extension.extensionId);
+    await extension.setServerBaseUrl(`http://127.0.0.1:${port}`);
+
+    const targetPage = await extension.context.newPage();
+    await installAutomationFixture(targetPage, `http://127.0.0.1:${port}/automation-fixture`);
+
+    const popupPage = await openExtensionPage(extension.context, extension.extensionId, 'popup.html');
+    await configureAutomation(popupPage);
+    const { sessionId, tabId } = await startSessionFromTargetTab(popupPage, targetPage);
+    await expectMcpSeesLiveSession(mcp, sessionId);
+
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      await expect(callToolJson(mcp.client, 'get_dom_subtree', {
+        sessionId,
+        selector: '#cross-origin-action',
+        maxBytes: 1500,
+      })).rejects.toThrow(/No element found for selector: #cross-origin-action/);
+    }
+
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      const subtree = await callToolJson<{ html?: string }>(mcp.client, 'get_dom_subtree', {
+        sessionId,
+        selector: '#cross-origin-action',
+        frameUrlContains: '/automation-cross-origin-frame',
+        maxBytes: 1500,
+      });
+      expect(subtree.html).toContain('id="cross-origin-action"');
+    }
+
+    const documentCapture = await callToolJson<{ outline?: string }>(mcp.client, 'get_dom_document', {
+      sessionId,
+      frameUrlContains: '/automation-cross-origin-frame',
+      mode: 'outline',
+      maxDepth: 4,
+    });
+    expect(documentCapture.outline).toContain('cross-origin-action');
+
+    const layout = await callToolJson<{
+      element?: { width?: number; height?: number };
+    }>(mcp.client, 'get_layout_metrics', {
+      sessionId,
+      selector: '#cross-origin-action',
+      frameUrlContains: '/automation-cross-origin-frame',
+    });
+    expect(layout.element?.width).toBeGreaterThan(0);
+    expect(layout.element?.height).toBeGreaterThan(0);
+
+    const styles = await callToolJson<{
+      properties?: { display?: string };
+    }>(mcp.client, 'get_computed_styles', {
+      sessionId,
+      selector: '#cross-origin-action',
+      frameUrlContains: '/automation-cross-origin-frame',
+      properties: ['display'],
+    });
+    expect(styles.properties?.display).toEqual(expect.any(String));
+    expect(styles.properties?.display).not.toBe('none');
+
+    const pageState = await callToolJson<{
+      buttons?: Array<{ selector?: string; elementRef?: string; frameId?: number }>;
+    }>(mcp.client, 'get_page_state', {
+      sessionId,
+      frameUrlContains: '/automation-cross-origin-frame',
+      includeButtons: true,
+      includeLinks: false,
+      includeInputs: false,
+      includeModals: false,
+    });
+    const targetButton = pageState.buttons?.find((button) => button.selector === '#cross-origin-action');
+    expect(targetButton?.elementRef).toEqual(expect.any(String));
+    expect(targetButton?.frameId).toEqual(expect.any(Number));
+
+    const click = await callToolJson<LiveActionResponse>(mcp.client, 'execute_ui_action', {
+      sessionId,
+      action: 'click',
+      target: {
+        elementRef: targetButton?.elementRef,
+        tabId,
+      },
+    });
+    expect(click.status).toBe('succeeded');
+    expect(click.target?.frameId).toBe(targetButton?.frameId);
+    await expect(targetPage.frameLocator('#cross-origin-frame').locator('#cross-origin-count')).toHaveText('1');
+
+    await targetPage.goto(`http://localhost:${port}/automation-cross-origin-frame`);
+    await expect(callToolJson(mcp.client, 'get_dom_document', {
+      sessionId,
+      mode: 'outline',
+    })).rejects.toThrow(/target tab is no longer allowlisted/);
+  });
+
   test('executes native top-document and same-origin iframe actions through the bound browser tab', async () => {
     const port = await getFreePort();
     mcp = await connectMcpClient(createTempDataDir('bdmcp-e2e-live-automation-'), { port });

--- a/apps/e2e-playwright/tests/full.override-poc.spec.ts
+++ b/apps/e2e-playwright/tests/full.override-poc.spec.ts
@@ -773,7 +773,7 @@ async function enableOverrideForTabViaMcp(
   if (!reloadResult.navigated) {
     throw new Error(`Target page did not reload after enabling override through MCP: ${reloadResult.error}`);
   }
-  await targetPage.waitForLoadState('domcontentloaded');
+  await targetPage.waitForLoadState('networkidle');
 }
 
 async function expectMcpOverrideRequestLogForUrlStatus(
@@ -886,7 +886,7 @@ async function enableOverrideForTab(popupPage: Page, targetPage: Page, tabId: nu
   if (!reloadResult.navigated) {
     throw new Error(`Target page did not reload after enabling override: ${reloadResult.error}`);
   }
-  await targetPage.waitForLoadState('domcontentloaded');
+  await targetPage.waitForLoadState('networkidle');
 }
 
 async function stopHarness(

--- a/apps/mcp-server/src/mcp/server.spec.ts
+++ b/apps/mcp-server/src/mcp/server.spec.ts
@@ -4222,7 +4222,7 @@ describe('mcp/server V2 capture tools', () => {
     expect((response.buttons as Array<Record<string, unknown>>)[0]?.text).toBe('Calcola target');
   });
 
-  it('forwards tabId through page-state based live tools', async () => {
+  it('forwards tab and frame targeting through page-state based live tools', async () => {
     const captureCalls: Array<{ command: string; payload: Record<string, unknown> }> = [];
     const tools = createToolRegistry(
       createV2ToolHandlers({
@@ -4245,12 +4245,15 @@ describe('mcp/server V2 capture tools', () => {
     await routeToolCall(tools, 'get_page_state', {
       sessionId: 'session-v2',
       tabId: 17,
+      frameId: 181,
+      frameUrlContains: 'player.hotmart.com',
       maxItems: 5,
     });
 
     await routeToolCall(tools, 'get_interactive_elements', {
       sessionId: 'session-v2',
       tabId: 17,
+      frameUrlContains: 'js.stripe.com',
       kinds: ['buttons'],
     });
 
@@ -4265,6 +4268,8 @@ describe('mcp/server V2 capture tools', () => {
           includeInputs: true,
           includeModals: true,
           tabId: 17,
+          frameId: 181,
+          frameUrlContains: 'player.hotmart.com',
         },
       },
       {
@@ -4277,6 +4282,7 @@ describe('mcp/server V2 capture tools', () => {
           includeInputs: false,
           includeModals: false,
           tabId: 17,
+          frameUrlContains: 'js.stripe.com',
         },
       },
     ]);
@@ -4372,9 +4378,11 @@ describe('mcp/server V2 capture tools', () => {
   });
 
   it('asserts structured page-state conditions through the v2 capture path', async () => {
+    const capturePayloads: Record<string, unknown>[] = [];
     const tools = createToolRegistry(
       createV2ToolHandlers({
-        execute: async () => {
+        execute: async (_sessionId, _command, payload) => {
+          capturePayloads.push(payload);
           return {
             ok: true,
             payload: {
@@ -4385,7 +4393,12 @@ describe('mcp/server V2 capture tools', () => {
               summary: { buttons: 8, inputs: 5, modals: 0 },
               buttons: [
                 { text: 'Calcola target', selector: '#build', disabled: false },
-                { text: 'Settimana', selector: '#week', disabled: true },
+                {
+                  text: 'Settimana',
+                  selector: '#week',
+                  disabled: true,
+                  frameUrl: 'https://player.hotmart.com/embed',
+                },
               ],
             },
             truncated: false,
@@ -4398,20 +4411,24 @@ describe('mcp/server V2 capture tools', () => {
       sessionId: 'session-v2',
       scope: 'buttons',
       textContains: 'Settimana',
+      frameUrlContains: 'player.hotmart.com',
       disabled: true,
     });
 
     expect(response.matched).toBe(true);
     expect(response.matchCount).toBe(1);
     expect((response.sampledMatches as Array<Record<string, unknown>>)[0]?.selector).toBe('#week');
+    expect(capturePayloads[0]).not.toHaveProperty('frameUrlContains');
   });
 
   it('waits for a structured page-state condition to become true', async () => {
     let attempt = 0;
+    const capturePayloads: Record<string, unknown>[] = [];
     const tools = createToolRegistry(
       createV2ToolHandlers({
-        execute: async () => {
+        execute: async (_sessionId, _command, payload) => {
           attempt += 1;
+          capturePayloads.push(payload);
           return {
             ok: true,
             payload: {
@@ -4422,7 +4439,13 @@ describe('mcp/server V2 capture tools', () => {
               summary: { buttons: 2, inputs: 1, modals: attempt >= 2 ? 1 : 0 },
               modals:
                 attempt >= 2
-                  ? [{ title: 'Day plan', selector: '[role="dialog"]', buttonCount: 2, fieldCount: 0 }]
+                  ? [{
+                      title: 'Day plan',
+                      selector: '[role="dialog"]',
+                      buttonCount: 2,
+                      fieldCount: 0,
+                      frameUrl: 'https://player.hotmart.com/embed',
+                    }]
                   : [],
             },
             truncated: false,
@@ -4435,6 +4458,7 @@ describe('mcp/server V2 capture tools', () => {
       sessionId: 'session-v2',
       scope: 'modals',
       titleContains: 'Day plan',
+      frameUrlContains: 'player.hotmart.com',
       timeoutMs: 500,
       pollIntervalMs: 10,
     });
@@ -4442,6 +4466,7 @@ describe('mcp/server V2 capture tools', () => {
     expect(response.matched).toBe(true);
     expect(response.attempts).toBeGreaterThanOrEqual(2);
     expect(response.waitedMs).toBeGreaterThanOrEqual(0);
+    expect(capturePayloads.every((payload) => !('frameUrlContains' in payload))).toBe(true);
   });
 
   it('preflights production-like automation flows with session, page, and risk diagnostics', async () => {
@@ -6594,7 +6619,7 @@ describe('mcp/server V2 capture tools', () => {
     expect(response.limitsApplied).toEqual({ maxResults: 5000, truncated: true });
   });
 
-  it('forwards tabId for dom document capture tools', async () => {
+  it('forwards tab and frame targeting for DOM and layout capture tools', async () => {
     const captureCalls: Array<{ command: string; payload: Record<string, unknown> }> = [];
     const tools = createToolRegistry(
       createV2ToolHandlers({
@@ -6614,20 +6639,73 @@ describe('mcp/server V2 capture tools', () => {
     await routeToolCall(tools, 'get_dom_document', {
       sessionId: 'session-v2',
       tabId: 42,
+      frameUrlContains: 'player.hotmart.com',
       mode: 'outline',
       maxDepth: 5,
       maxBytes: 9000,
     });
 
-    expect(captureCalls).toEqual([{
-      command: 'CAPTURE_DOM_DOCUMENT',
-      payload: {
-        mode: 'outline',
-        maxBytes: 9000,
-        maxDepth: 5,
-        tabId: 42,
+    await routeToolCall(tools, 'get_dom_subtree', {
+      sessionId: 'session-v2',
+      tabId: 42,
+      frameId: 181,
+      selector: 'video',
+      maxDepth: 3,
+      maxBytes: 1500,
+    });
+
+    await routeToolCall(tools, 'get_layout_metrics', {
+      sessionId: 'session-v2',
+      selector: 'video',
+      frameUrlContains: 'player.hotmart.com',
+    });
+
+    expect(captureCalls).toEqual([
+      {
+        command: 'CAPTURE_DOM_DOCUMENT',
+        payload: {
+          mode: 'outline',
+          maxBytes: 9000,
+          maxDepth: 5,
+          tabId: 42,
+          frameUrlContains: 'player.hotmart.com',
+        },
       },
-    }]);
+      {
+        command: 'CAPTURE_DOM_SUBTREE',
+        payload: {
+          selector: 'video',
+          maxDepth: 3,
+          maxBytes: 1500,
+          tabId: 42,
+          frameId: 181,
+        },
+      },
+      {
+        command: 'CAPTURE_LAYOUT_METRICS',
+        payload: {
+          selector: 'video',
+          frameUrlContains: 'player.hotmart.com',
+        },
+      },
+    ]);
+  });
+
+  it('rejects malformed capture frame targets', async () => {
+    const tools = createToolRegistry(
+      createV2ToolHandlers({
+        execute: async () => ({ ok: true, payload: {} }),
+      }),
+    );
+
+    await expect(routeToolCall(tools, 'get_layout_metrics', {
+      sessionId: 'session-v2',
+      frameId: 1.5,
+    })).rejects.toThrow('frameId must be a non-negative integer');
+    await expect(routeToolCall(tools, 'get_layout_metrics', {
+      sessionId: 'session-v2',
+      frameUrlContains: ' ',
+    })).rejects.toThrow('frameUrlContains must be a non-empty string');
   });
 
   it('requests only specified computed style properties', async () => {
@@ -6636,6 +6714,7 @@ describe('mcp/server V2 capture tools', () => {
         execute: async (_sessionId, command, payload) => {
           expect(command).toBe('CAPTURE_COMPUTED_STYLES');
           expect(payload.properties).toEqual(['display', 'visibility']);
+          expect(payload.frameUrlContains).toBe('player.hotmart.com');
 
           return {
             ok: true,
@@ -6655,6 +6734,7 @@ describe('mcp/server V2 capture tools', () => {
       sessionId: 'session-v2',
       selector: '.target',
       properties: ['display', 'visibility'],
+      frameUrlContains: 'player.hotmart.com',
     });
 
     expect(response.selector).toBe('.target');

--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -1026,6 +1026,8 @@ const TOOL_SCHEMAS: Record<string, object> = {
     properties: {
       sessionId: { type: 'string' },
       tabId: { type: 'number' },
+      frameId: { type: 'integer', minimum: 0 },
+      frameUrlContains: { type: 'string', minLength: 1 },
       selector: { type: 'string' },
       maxDepth: { type: 'number' },
       maxBytes: { type: 'number' },
@@ -1037,6 +1039,8 @@ const TOOL_SCHEMAS: Record<string, object> = {
     properties: {
       sessionId: { type: 'string' },
       tabId: { type: 'number' },
+      frameId: { type: 'integer', minimum: 0 },
+      frameUrlContains: { type: 'string', minLength: 1 },
       mode: { type: 'string' },
       maxBytes: { type: 'number' },
       maxDepth: { type: 'number' },
@@ -1048,7 +1052,8 @@ const TOOL_SCHEMAS: Record<string, object> = {
     properties: {
       sessionId: { type: 'string' },
       selector: { type: 'string' },
-      frameId: { type: 'number' },
+      frameId: { type: 'integer', minimum: 0 },
+      frameUrlContains: { type: 'string', minLength: 1 },
       properties: { type: 'array', items: { type: 'string' } },
     },
   },
@@ -1058,7 +1063,8 @@ const TOOL_SCHEMAS: Record<string, object> = {
     properties: {
       sessionId: { type: 'string' },
       selector: { type: 'string' },
-      frameId: { type: 'number' },
+      frameId: { type: 'integer', minimum: 0 },
+      frameUrlContains: { type: 'string', minLength: 1 },
     },
   },
   get_page_state: {
@@ -1067,6 +1073,8 @@ const TOOL_SCHEMAS: Record<string, object> = {
     properties: {
       sessionId: { type: 'string' },
       tabId: { type: 'number' },
+      frameId: { type: 'integer', minimum: 0 },
+      frameUrlContains: { type: 'string', minLength: 1 },
       maxItems: { type: 'number' },
       maxTextLength: { type: 'number' },
       includeButtons: { type: 'boolean' },
@@ -1081,6 +1089,8 @@ const TOOL_SCHEMAS: Record<string, object> = {
     properties: {
       sessionId: { type: 'string' },
       tabId: { type: 'number' },
+      frameId: { type: 'integer', minimum: 0 },
+      frameUrlContains: { type: 'string', minLength: 1 },
       kinds: {
         type: 'array',
         items: { type: 'string', enum: ['buttons', 'links', 'inputs', 'modals', 'focused'] },
@@ -2159,12 +2169,12 @@ const TOOL_DESCRIPTIONS: Record<string, string> = {
   get_request_trace: 'Get correlated UI/events/network chain by requestId or traceId',
   get_body_chunk: 'Retrieve a chunk from a stored large body payload',
   get_element_refs: 'Get element references by selector',
-  get_dom_subtree: 'Capture a bounded DOM subtree',
-  get_dom_document: 'Capture full document as outline or html',
-  get_computed_styles: 'Read computed CSS styles for an element',
-  get_layout_metrics: 'Read viewport and element layout metrics',
-  get_page_state: 'Read a compact structured page model for forms, buttons, modals, and viewport state',
-  get_interactive_elements: 'Read compact live element references for buttons, links, inputs, modals, and focused elements',
+  get_dom_subtree: 'Capture a bounded DOM subtree in the top document or one explicitly targeted frame',
+  get_dom_document: 'Capture the top document or one explicitly targeted frame as outline or html',
+  get_computed_styles: 'Read computed CSS styles for an element in the top document or one explicitly targeted frame',
+  get_layout_metrics: 'Read viewport and element layout metrics in the top document or one explicitly targeted frame',
+  get_page_state: 'Read an aggregate or frame-targeted compact page model for forms, buttons, modals, and viewport state',
+  get_interactive_elements: 'Read aggregate or frame-targeted live refs for buttons, links, inputs, modals, and focused elements',
   get_live_session_health: 'Read live transport health and session binding details for one session',
   set_viewport: 'Resize the live browser window for a session and return the resulting viewport metrics',
   assert_page_state: 'Assert compact page-state conditions without pulling raw DOM payloads',
@@ -7087,6 +7097,46 @@ function resolveOptionalTabId(value: unknown): number | undefined {
   return tabId;
 }
 
+function resolveOptionalFrameId(value: unknown): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+    throw new Error('frameId must be a non-negative integer');
+  }
+
+  return value;
+}
+
+function resolveOptionalFrameUrlContains(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error('frameUrlContains must be a non-empty string');
+  }
+
+  return value.trim();
+}
+
+function resolveCaptureFrameTarget(
+  input: ToolInput,
+  options: { defaultFrameId?: number } = {},
+): Record<string, unknown> {
+  const frameId = resolveOptionalFrameId(input.frameId);
+  const frameUrlContains = resolveOptionalFrameUrlContains(input.frameUrlContains);
+
+  return {
+    ...(frameId !== undefined
+      ? { frameId }
+      : frameUrlContains === undefined && options.defaultFrameId !== undefined
+        ? { frameId: options.defaultFrameId }
+        : {}),
+    ...(frameUrlContains !== undefined ? { frameUrlContains } : {}),
+  };
+}
+
 function isLiveSessionDisconnectedMessage(message: string): boolean {
   const normalized = message.toLowerCase();
   return normalized.includes('no active extension connection')
@@ -10437,6 +10487,7 @@ export function createV2ToolHandlers(
   const capturePageState = async (
     sessionId: string,
     input: ToolInput,
+    includeFrameTarget = false,
   ): Promise<{ limitsApplied: { maxResults: number; truncated: boolean }; payload: Record<string, unknown> }> => {
     const maxItems = resolveStructuredMaxItems(input.maxItems, 40);
     const maxTextLength = resolveStructuredTextLength(input.maxTextLength, 80);
@@ -10456,6 +10507,7 @@ export function createV2ToolHandlers(
         includeInputs,
         includeModals,
         tabId: resolveOptionalTabId(input.tabId),
+        ...(includeFrameTarget ? resolveCaptureFrameTarget(input) : {}),
       },
       4_000,
     );
@@ -11139,7 +11191,13 @@ export function createV2ToolHandlers(
         captureClient,
         sessionId,
         'CAPTURE_DOM_SUBTREE',
-        { selector, maxDepth, maxBytes, tabId: resolveOptionalTabId(input.tabId) },
+        {
+          selector,
+          maxDepth,
+          maxBytes,
+          tabId: resolveOptionalTabId(input.tabId),
+          ...resolveCaptureFrameTarget(input),
+        },
         4_000,
       );
 
@@ -11168,7 +11226,13 @@ export function createV2ToolHandlers(
           captureClient,
           sessionId,
           'CAPTURE_DOM_DOCUMENT',
-          { mode, maxBytes, maxDepth, tabId: resolveOptionalTabId(input.tabId) },
+          {
+            mode,
+            maxBytes,
+            maxDepth,
+            tabId: resolveOptionalTabId(input.tabId),
+            ...resolveCaptureFrameTarget(input),
+          },
           4_000,
         );
 
@@ -11190,7 +11254,13 @@ export function createV2ToolHandlers(
           captureClient,
           sessionId,
           'CAPTURE_DOM_DOCUMENT',
-          { mode: 'outline', maxBytes, maxDepth, tabId: resolveOptionalTabId(input.tabId) },
+          {
+            mode: 'outline',
+            maxBytes,
+            maxDepth,
+            tabId: resolveOptionalTabId(input.tabId),
+            ...resolveCaptureFrameTarget(input),
+          },
           4_000,
         );
 
@@ -11218,14 +11288,15 @@ export function createV2ToolHandlers(
       }
 
       const properties = asStringArray(input.properties, 64);
-      const frameId = typeof input.frameId === 'number' && Number.isFinite(input.frameId)
-        ? Math.max(0, Math.floor(input.frameId))
-        : 0;
       const capture = await executeLiveCapture(
         captureClient,
         sessionId,
         'CAPTURE_COMPUTED_STYLES',
-        { selector, frameId, properties },
+        {
+          selector,
+          properties,
+          ...resolveCaptureFrameTarget(input, { defaultFrameId: 0 }),
+        },
         3_000,
       );
 
@@ -11246,14 +11317,14 @@ export function createV2ToolHandlers(
       }
 
       const selector = typeof input.selector === 'string' ? input.selector : undefined;
-      const frameId = typeof input.frameId === 'number' && Number.isFinite(input.frameId)
-        ? Math.max(0, Math.floor(input.frameId))
-        : 0;
       const capture = await executeLiveCapture(
         captureClient,
         sessionId,
         'CAPTURE_LAYOUT_METRICS',
-        { selector, frameId },
+        {
+          selector,
+          ...resolveCaptureFrameTarget(input, { defaultFrameId: 0 }),
+        },
         3_000,
       );
 
@@ -11273,7 +11344,7 @@ export function createV2ToolHandlers(
         throw new Error('sessionId is required');
       }
 
-      const capture = await capturePageState(sessionId, input);
+      const capture = await capturePageState(sessionId, input, true);
 
       return {
         ...createBaseResponse(sessionId),
@@ -11296,7 +11367,7 @@ export function createV2ToolHandlers(
         includeInputs: kinds.includes('inputs'),
         includeModals: kinds.includes('modals'),
       };
-      const capture = await capturePageState(sessionId, normalizedInput);
+      const capture = await capturePageState(sessionId, normalizedInput, true);
       const refs = collectInteractiveElementRefs(capture.payload, kinds, capture.limitsApplied.maxResults);
 
       return {

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -273,6 +273,18 @@ Returns selector references associated with captured UI events.
 
 ## V2 Heavy on-demand tools
 
+DOM, style, and layout captures default to Chrome's top frame (`frameId: 0`) instead of accepting
+whichever frame replies first. To capture a child frame, pass either its numeric `frameId` or a
+case-insensitive `frameUrlContains` substring. URL targeting must identify exactly one frame;
+zero or multiple matches return an explicit error. Supplying both fields verifies that the frame
+ID still belongs to the expected URL. Frame targeting keeps the existing session binding and
+top-tab allowlist checks.
+
+`get_page_state` and `get_interactive_elements` keep their aggregate-across-frames behavior when
+no frame target is supplied. Passing `frameId` or `frameUrlContains` limits either tool to that
+single frame. For `assert_page_state` and `wait_for_page_state`, `frameUrlContains` remains an item
+matcher over the aggregate page model.
+
 ### get_dom_subtree
 
 Captures a reduced DOM subtree for a selector.
@@ -283,6 +295,7 @@ Captures a reduced DOM subtree for a selector.
   "arguments": {
     "sessionId": "sess_123",
     "selector": "#checkout-form",
+    "frameUrlContains": "checkout.example.com",
     "maxDepth": 5,
     "maxBytes": 120000
   }
@@ -307,6 +320,7 @@ Returns only requested CSS properties.
   "arguments": {
     "sessionId": "sess_123",
     "selector": ".submit-button",
+    "frameUrlContains": "checkout.example.com",
     "properties": ["display", "visibility", "opacity", "z-index"]
   }
 }
@@ -317,7 +331,14 @@ Returns only requested CSS properties.
 Returns layout and bounding-box metrics for a selector.
 
 ```json
-{ "name": "get_layout_metrics", "arguments": { "sessionId": "sess_123", "selector": ".modal" } }
+{
+  "name": "get_layout_metrics",
+  "arguments": {
+    "sessionId": "sess_123",
+    "selector": ".modal",
+    "frameUrlContains": "checkout.example.com"
+  }
+}
 ```
 
 ### get_page_state
@@ -329,6 +350,7 @@ Returns a compact structured page model so flows can avoid repeated large DOM ca
   "name": "get_page_state",
   "arguments": {
     "sessionId": "sess_123",
+    "frameId": 0,
     "maxItems": 40,
     "maxTextLength": 80,
     "includeButtons": true,
@@ -359,6 +381,7 @@ Returns compact live refs for interactive elements so automation can reuse `elem
   "name": "get_interactive_elements",
   "arguments": {
     "sessionId": "sess_123",
+    "frameUrlContains": "checkout.example.com",
     "kinds": ["buttons", "inputs", "focused"],
     "maxItems": 20
   }


### PR DESCRIPTION
## Summary
- make DOM, layout, style, and UI snapshot captures default deterministically to the top frame
- add strict `frameId` / unique `frameUrlContains` targeting while preserving aggregate page-state semantics
- keep command-time top-tab allowlist enforcement and selected-frame recovery
- add real-browser multi-frame regression coverage and stabilize override tests by waiting for hydration
- document frame targeting and matcher semantics

Issue #31 note: its `maxBodyBytes` bug was already shipped by #32 in v1.14.1; this completes the remaining DOM-capture failure.

## Validation
- lint, typecheck, build, docs CI, stdio guard, and package smoke
- 549 non-E2E tests
- full Playwright E2E: 38/38

Closes #31
Closes #34