### PR TITLE
fix(extension): keep key dispatch on session tab

### DIFF
--- a/apps/chrome-extension/src/automation-native.spec.ts
+++ b/apps/chrome-extension/src/automation-native.spec.ts
@@ -1596,6 +1596,40 @@ describe('native automation backend', () => {
     );
   });
 
+  it('reports the resolved tab when native key dispatch fails', async () => {
+    const chromeMock = installChromeMock();
+    chromeMock.attach.mockRejectedValueOnce(
+      new Error('Cannot access a chrome-extension:// URL of different extension'),
+    );
+    const request: Extract<LiveUIActionRequest, { action: 'press_key' }> = {
+      action: 'press_key',
+      traceId: 'trace-key-failed',
+      input: {
+        key: 'k',
+      },
+    };
+
+    const result = await executeNativePressKeyAction({
+      request,
+      tab: {
+        id: 7,
+        url: 'https://example.com/settings',
+      } as chrome.tabs.Tab & { id: number },
+      startedAt: 1000,
+      traceId: 'trace-key-failed',
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.target).toMatchObject({
+      tabId: 7,
+      url: 'https://example.com/settings',
+    });
+    expect(result.failureReason).toEqual({
+      code: 'native_key_dispatch_failed',
+      message: 'Native key dispatch failed for tabId 7 (https://example.com/settings): Cannot access a chrome-extension:// URL of different extension',
+    });
+  });
+
   it('focuses and blurs native targets through the page context', async () => {
     const chromeMock = installChromeMock([
       targetSnapshot,

--- a/apps/chrome-extension/src/automation-native.ts
+++ b/apps/chrome-extension/src/automation-native.ts
@@ -4162,13 +4162,15 @@ export async function executeNativePressKeyAction(options: NativePressKeyExecuti
       },
     };
   } catch (error) {
+    const detail = error instanceof Error ? error.message : 'Unknown Chrome debugger error.';
+    const targetUrl = tab.url ? ` (${tab.url})` : '';
     return buildFailedResult(
       request,
       tab,
       startedAt,
       traceId,
       'native_key_dispatch_failed',
-      error instanceof Error ? error.message : 'Native key dispatch failed.',
+      `Native key dispatch failed for tabId ${tab.id}${targetUrl}: ${detail}`,
     );
   }
 }

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -3048,6 +3048,7 @@ async function resolveCaptureTab(sessionId: string): Promise<chrome.tabs.Tab | u
     activeTabId: typeof active?.id === 'number' ? active.id : undefined,
     rememberedTabId: remembered?.tabId,
     allowedTabIds,
+    allowActiveTab: scope !== undefined,
   });
 
   for (const candidateTabId of candidateTabIds) {

--- a/apps/chrome-extension/src/live-capture-routing.spec.ts
+++ b/apps/chrome-extension/src/live-capture-routing.spec.ts
@@ -15,6 +15,15 @@ describe('live capture routing helpers', () => {
     })).toEqual([9, 4, 12]);
   });
 
+  it('ignores the active tab when session scope is unavailable', () => {
+    expect(buildPreferredCaptureTabIds({
+      activeTabId: 9,
+      rememberedTabId: 4,
+      allowedTabIds: [],
+      allowActiveTab: false,
+    })).toEqual([4]);
+  });
+
   it('retries empty outline document captures', () => {
     expect(shouldRetryGenericCaptureResult('CAPTURE_DOM_DOCUMENT', {
       mode: 'outline',

--- a/apps/chrome-extension/src/live-capture-routing.ts
+++ b/apps/chrome-extension/src/live-capture-routing.ts
@@ -17,6 +17,7 @@ type CaptureTabPreferenceOptions = {
   activeTabId?: number;
   rememberedTabId?: number;
   allowedTabIds?: number[];
+  allowActiveTab?: boolean;
 };
 
 type DomDocumentPayload = {
@@ -148,7 +149,9 @@ export function buildPreferredCaptureTabIds(options: CaptureTabPreferenceOptions
     ordered.push(value);
   };
 
-  push(options.activeTabId);
+  if (options.allowActiveTab !== false) {
+    push(options.activeTabId);
+  }
   push(options.rememberedTabId);
   for (const tabId of options.allowedTabIds ?? []) {
     push(tabId);


### PR DESCRIPTION
## Summary

- prevent session actions from falling back to an unrelated active tab when persisted scope metadata is unavailable
- keep the remembered session tab as the only safe fallback in that state
- wrap native keyboard dispatch errors with the resolved tab ID and URL
- add regression coverage for both routing and error attribution

## Root cause

When session scope metadata was absent after restoration, capture/action routing still preferred the globally active tab before the remembered session tab. If another extension page was focused, `press_key` attempted to attach Chrome Debugger there and leaked Chrome's raw cross-extension error.

## Validation

- `pnpm verify:ci`
- extension tests: 150/150
- Playwright smoke: 3/3
- Playwright full: 38/38

Closes #36