### PR TITLE
fix(capture): reject unknown keys and report resolved frames

### DIFF
--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -3514,13 +3514,30 @@ async function listTabFrames(tabId: number): Promise<FrameCaptureMetadata[]> {
 async function resolveCaptureCommandFrame(
   tabId: number,
   payload: Record<string, unknown>,
+  topFrame: FrameCaptureMetadata = { frameId: 0 },
 ): Promise<FrameCaptureMetadata> {
   if (!hasExplicitCaptureFrameTarget(payload)) {
-    return { frameId: 0 };
+    return topFrame;
   }
 
   const frames = await listTabFrames(tabId);
   return resolveCaptureFrameTarget(frames, payload);
+}
+
+function withResolvedFrame(
+  capture: { payload: Record<string, unknown>; truncated?: boolean },
+  frame: FrameCaptureMetadata,
+): { payload: Record<string, unknown>; truncated?: boolean } {
+  return {
+    ...capture,
+    payload: {
+      ...capture.payload,
+      resolvedFrame: {
+        frameId: frame.frameId,
+        url: resolveFrameMetadataUrl(frame),
+      },
+    },
+  };
 }
 
 function mergeFramePageStates(
@@ -3709,19 +3726,15 @@ async function executeRetriableGenericCapture(
   };
   let capture = await captureOnce();
 
-  if (!shouldRetryGenericCaptureResult(command, capture.payload)) {
-    return capture;
+  if (shouldRetryGenericCaptureResult(command, capture.payload)) {
+    await sleep(150);
+    const contentReady = await ensureContentScriptReady(tabId, frame?.frameId ?? 0);
+    if (contentReady) {
+      capture = await captureOnce();
+    }
   }
 
-  await sleep(150);
-  const contentReady = await ensureContentScriptReady(tabId, frame?.frameId ?? 0);
-  if (!contentReady) {
-    return capture;
-  }
-
-  capture = await captureOnce();
-
-  return capture;
+  return frame ? withResolvedFrame(capture, frame) : capture;
 }
 
 function buildCaptureConfigUpdatePayload(sessionId?: string): CaptureConfigUpdatePayload {
@@ -4550,6 +4563,12 @@ async function executeCaptureCommand(
   rememberCaptureTabForSession(context.sessionId, tab);
 
   const tabId = tab.id;
+  const topFrame: FrameCaptureMetadata = {
+    frameId: 0,
+    url: tab.url,
+    title: tab.title,
+    origin: normalizeHttpOrigin(tab.url),
+  };
   const contentReady = await ensureContentScriptReady(tabId);
   if (!contentReady) {
     throw new Error('Target tab for this session is unavailable for live capture');
@@ -4597,7 +4616,7 @@ async function executeCaptureCommand(
 
   if (command === 'CAPTURE_PAGE_STATE') {
     const frame = hasExplicitCaptureFrameTarget(payload)
-      ? await resolveCaptureCommandFrame(tabId, payload)
+      ? await resolveCaptureCommandFrame(tabId, payload, topFrame)
       : undefined;
     return executeRetriableGenericCapture(tabId, 'CAPTURE_PAGE_STATE', payload, frame);
   }
@@ -4756,12 +4775,15 @@ async function executeCaptureCommand(
   }
 
   if (command === 'CAPTURE_DOM_DOCUMENT' || command === 'CAPTURE_DOM_SUBTREE') {
-    const frame = await resolveCaptureCommandFrame(tabId, payload);
+    const frame = await resolveCaptureCommandFrame(tabId, payload, topFrame);
     return executeRetriableGenericCapture(tabId, command, payload, frame);
   }
 
-  const frame = await resolveCaptureCommandFrame(tabId, payload);
-  return sendCaptureCommandToTab(tabId, command, payload, true, frame.frameId);
+  const frame = await resolveCaptureCommandFrame(tabId, payload, topFrame);
+  return withResolvedFrame(
+    await sendCaptureCommandToTab(tabId, command, payload, true, frame.frameId),
+    frame,
+  );
 }
 
 const sessionManager = new SessionManager({

--- a/apps/docs/docs/mcp-tools/v2-heavy-capture.md
+++ b/apps/docs/docs/mcp-tools/v2-heavy-capture.md
@@ -17,6 +17,32 @@ provided. Passing either targeting field limits the result to one frame.
 For `assert_page_state` and `wait_for_page_state`, `frameUrlContains` remains an item matcher over
 the aggregate page model.
 
+Single-frame DOM, style, layout, and targeted page-state responses include
+`resolvedFrame: { frameId, url }`. Untargeted page-state responses describe every contributing
+frame in `frames`.
+
+### Targeting capability matrix
+
+`✓` means supported. `—` means unsupported and rejected as an unknown payload key.
+
+| Raw command | `tabId` | `frameId` | `frameUrlContains` | Default scope |
+| --- | --- | --- | --- | --- |
+| `CAPTURE_DOM_SUBTREE` | ✓ | ✓ | ✓ | Top frame |
+| `CAPTURE_DOM_DOCUMENT` | ✓ | ✓ | ✓ | Top frame |
+| `CAPTURE_COMPUTED_STYLES` | ✓ | ✓ | ✓ | Top frame |
+| `CAPTURE_LAYOUT_METRICS` | ✓ | ✓ | ✓ | Top frame |
+| `CAPTURE_PAGE_STATE` | ✓ | ✓ | ✓ | All frames |
+| `CAPTURE_UI_SNAPSHOT`, `SET_VIEWPORT` | ✓ | — | — | Top frame |
+| `CAPTURE_GET_LIVE_CONSOLE_LOGS` | ✓ | — | — | Session buffer |
+| Navigation, dialog, stable-layout, and download waits | ✓ | — | — | Bound session tab |
+| `CAPTURE_WAIT_FOR_POPUP` | `openerTabId` | — | — | Bound opener tab |
+| Override observe, response-body, and enable commands | ✓ | — | — | Bound override tab |
+| Override status and disable commands | — | — | — | Active override |
+| `EXECUTE_UI_ACTION` | `target.tabId` | `target.frameId` | `target.frameUrlContains` | Bound session tab |
+
+The raw `/internal/capture-command` boundary is strict for every command: an unknown payload key
+returns HTTP 400 with the offending and accepted keys. No payload key is silently ignored.
+
 ## `get_dom_subtree`
 
 ```json

--- a/apps/e2e-playwright/tests/full.live-automation.spec.ts
+++ b/apps/e2e-playwright/tests/full.live-automation.spec.ts
@@ -660,25 +660,35 @@ test.describe('@full live automation through MCP and extension session', () => {
     }
 
     for (let attempt = 0; attempt < 8; attempt += 1) {
-      const subtree = await callToolJson<{ html?: string }>(mcp.client, 'get_dom_subtree', {
+      const subtree = await callToolJson<{
+        html?: string;
+        resolvedFrame?: { frameId?: number; url?: string };
+      }>(mcp.client, 'get_dom_subtree', {
         sessionId,
         selector: '#cross-origin-action',
         frameUrlContains: '/automation-cross-origin-frame',
         maxBytes: 1500,
       });
       expect(subtree.html).toContain('id="cross-origin-action"');
+      expect(subtree.resolvedFrame?.frameId).toBeGreaterThan(0);
+      expect(subtree.resolvedFrame?.url).toContain('/automation-cross-origin-frame');
     }
 
-    const documentCapture = await callToolJson<{ outline?: string }>(mcp.client, 'get_dom_document', {
+    const documentCapture = await callToolJson<{
+      outline?: string;
+      resolvedFrame?: { frameId?: number; url?: string };
+    }>(mcp.client, 'get_dom_document', {
       sessionId,
       frameUrlContains: '/automation-cross-origin-frame',
       mode: 'outline',
       maxDepth: 4,
     });
     expect(documentCapture.outline).toContain('cross-origin-action');
+    expect(documentCapture.resolvedFrame?.url).toContain('/automation-cross-origin-frame');
 
     const layout = await callToolJson<{
       element?: { width?: number; height?: number };
+      resolvedFrame?: { frameId?: number; url?: string };
     }>(mcp.client, 'get_layout_metrics', {
       sessionId,
       selector: '#cross-origin-action',
@@ -686,9 +696,11 @@ test.describe('@full live automation through MCP and extension session', () => {
     });
     expect(layout.element?.width).toBeGreaterThan(0);
     expect(layout.element?.height).toBeGreaterThan(0);
+    expect(layout.resolvedFrame?.url).toContain('/automation-cross-origin-frame');
 
     const styles = await callToolJson<{
       properties?: { display?: string };
+      resolvedFrame?: { frameId?: number; url?: string };
     }>(mcp.client, 'get_computed_styles', {
       sessionId,
       selector: '#cross-origin-action',
@@ -697,9 +709,11 @@ test.describe('@full live automation through MCP and extension session', () => {
     });
     expect(styles.properties?.display).toEqual(expect.any(String));
     expect(styles.properties?.display).not.toBe('none');
+    expect(styles.resolvedFrame?.url).toContain('/automation-cross-origin-frame');
 
     const pageState = await callToolJson<{
       buttons?: Array<{ selector?: string; elementRef?: string; frameId?: number }>;
+      resolvedFrame?: { frameId?: number; url?: string };
     }>(mcp.client, 'get_page_state', {
       sessionId,
       frameUrlContains: '/automation-cross-origin-frame',
@@ -711,6 +725,8 @@ test.describe('@full live automation through MCP and extension session', () => {
     const targetButton = pageState.buttons?.find((button) => button.selector === '#cross-origin-action');
     expect(targetButton?.elementRef).toEqual(expect.any(String));
     expect(targetButton?.frameId).toEqual(expect.any(Number));
+    expect(pageState.resolvedFrame?.frameId).toBe(targetButton?.frameId);
+    expect(pageState.resolvedFrame?.url).toContain('/automation-cross-origin-frame');
 
     const click = await callToolJson<LiveActionResponse>(mcp.client, 'execute_ui_action', {
       sessionId,

--- a/apps/mcp-server/src/main.spec.ts
+++ b/apps/mcp-server/src/main.spec.ts
@@ -48,6 +48,28 @@ describe('MCP Server', () => {
     expect(body.websocket).toBeDefined();
   });
 
+  it('should reject unknown capture payload keys with accepted-key guidance', async () => {
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/internal/capture-command',
+      payload: {
+        sessionId: 'strict-capture-payload-test',
+        command: 'CAPTURE_PAGE_STATE',
+        payload: {
+          frameURLContains: 'checkout.example.com',
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body)).toEqual({
+      ok: false,
+      error: expect.stringContaining(
+        'Unknown payload key for CAPTURE_PAGE_STATE: frameURLContains. Accepted keys:',
+      ),
+    });
+  });
+
   it('should expose CLI tool discovery and protect generic tool execution', async () => {
     initializeDatabase(getConnection().db);
 

--- a/apps/mcp-server/src/main.ts
+++ b/apps/mcp-server/src/main.ts
@@ -53,6 +53,7 @@ import {
   listActiveBrowserMockRoutes,
 } from './mock-store.js';
 import { registerCliGateway } from './cli/gateway.js';
+import { CaptureCommandSchema, type CaptureCommand } from './websocket/messages.js';
 
 const fastify = Fastify({
   logger: process.env.MCP_STDIO_MODE === '1' ? false : true
@@ -70,9 +71,125 @@ let cleanupInterval: NodeJS.Timeout | null = null;
 let lastCleanupResult: ReturnType<typeof runRetentionCleanup> | null = null;
 const MAX_SESSION_IMPORT_BYTES = 10 * 1024 * 1024;
 const MOCK_ROUTE_LOCAL_PATH_PREFIX = 'bdmcp-mock-route:';
+const CAPTURE_PAYLOAD_KEYS: Record<CaptureCommand, readonly string[]> = {
+  CAPTURE_DOM_SUBTREE: ['selector', 'maxDepth', 'maxBytes', 'tabId', 'frameId', 'frameUrlContains'],
+  CAPTURE_DOM_DOCUMENT: ['mode', 'maxDepth', 'maxBytes', 'tabId', 'frameId', 'frameUrlContains'],
+  CAPTURE_COMPUTED_STYLES: ['selector', 'properties', 'tabId', 'frameId', 'frameUrlContains'],
+  CAPTURE_LAYOUT_METRICS: ['selector', 'tabId', 'frameId', 'frameUrlContains'],
+  CAPTURE_PAGE_STATE: [
+    'maxItems',
+    'maxTextLength',
+    'includeButtons',
+    'includeLinks',
+    'includeInputs',
+    'includeModals',
+    'tabId',
+    'frameId',
+    'frameUrlContains',
+  ],
+  CAPTURE_UI_SNAPSHOT: [
+    'selector',
+    'trigger',
+    'mode',
+    'styleMode',
+    'explicitStyleMode',
+    'maxDepth',
+    'maxBytes',
+    'maxAncestors',
+    'includeDom',
+    'includeStyles',
+    'includePngDataUrl',
+    'llmRequested',
+    'tabId',
+  ],
+  CAPTURE_GET_LIVE_CONSOLE_LOGS: [
+    'origin',
+    'url',
+    'tabId',
+    'levels',
+    'contains',
+    'sinceTs',
+    'includeRuntimeErrors',
+    'dedupeWindowMs',
+    'limit',
+  ],
+  CAPTURE_WAIT_FOR_NAVIGATION_LIFECYCLE: [
+    'state',
+    'urlContains',
+    'urlRegex',
+    'exactUrl',
+    'tabId',
+    'timeoutMs',
+  ],
+  CAPTURE_WAIT_FOR_DIALOG: [
+    'type',
+    'messageContains',
+    'urlContains',
+    'action',
+    'promptText',
+    'tabId',
+    'timeoutMs',
+  ],
+  CAPTURE_WAIT_FOR_STABLE_LAYOUT: ['selector', 'stableMs', 'tabId', 'timeoutMs', 'pollIntervalMs'],
+  CAPTURE_WAIT_FOR_DOWNLOAD: [
+    'urlContains',
+    'urlRegex',
+    'exactUrl',
+    'filenameContains',
+    'filenameRegex',
+    'state',
+    'tabId',
+    'timeoutMs',
+  ],
+  CAPTURE_WAIT_FOR_POPUP: ['urlContains', 'urlRegex', 'exactUrl', 'openerTabId', 'timeoutMs'],
+  CAPTURE_OVERRIDE_OBSERVE_ASSETS: ['tabId', 'includePerformance'],
+  CAPTURE_OVERRIDE_RESPONSE_BODY: [
+    'targetUrl',
+    'targetAssetUrl',
+    'tabId',
+    'captureMode',
+    'triggerReload',
+    'matchMode',
+    'ruleType',
+    'requestMethod',
+    'requestHeaders',
+    'timeoutMs',
+    'maxBodyBytes',
+    'includeBody',
+  ],
+  CAPTURE_OVERRIDE_POC_GET_STATUS: [],
+  CAPTURE_OVERRIDE_POC_ENABLE: ['tabId'],
+  CAPTURE_OVERRIDE_POC_DISABLE: [],
+  SET_VIEWPORT: ['width', 'height', 'tabId'],
+  EXECUTE_UI_ACTION: ['action', 'input', 'target', 'traceId'],
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function validateCapturePayload(
+  command: CaptureCommand,
+  payload: unknown,
+): Record<string, unknown> {
+  if (payload === undefined) {
+    return {};
+  }
+  if (!isRecord(payload)) {
+    throw new Error('payload must be an object');
+  }
+
+  const acceptedKeys = CAPTURE_PAYLOAD_KEYS[command];
+
+  const unknownKeys = Object.keys(payload).filter((key) => !acceptedKeys.includes(key));
+  if (unknownKeys.length > 0) {
+    throw new Error(
+      `Unknown payload key${unknownKeys.length === 1 ? '' : 's'} for ${command}: ${unknownKeys.join(', ')}. `
+      + `Accepted keys: ${acceptedKeys.join(', ') || '(none)'}`,
+    );
+  }
+
+  return payload;
 }
 
 function hasSession(sessionId: string): boolean {
@@ -658,26 +775,39 @@ fastify.get('/internal/session-connection/:sessionId', async (request, reply) =>
 fastify.post('/internal/capture-command', async (request, reply) => {
   const body = (request.body ?? {}) as Partial<{
     sessionId: string;
-    command: string;
-    payload: Record<string, unknown>;
+    command: unknown;
+    payload: unknown;
     timeoutMs: number;
   }>;
 
-  if (!wsManager) {
-    return reply.code(503).send({ ok: false, error: 'WebSocket manager unavailable' });
-  }
   if (typeof body.sessionId !== 'string' || body.sessionId.trim().length === 0) {
     return reply.code(400).send({ ok: false, error: 'sessionId is required' });
   }
-  if (typeof body.command !== 'string' || body.command.trim().length === 0) {
-    return reply.code(400).send({ ok: false, error: 'command is required' });
+
+  const command = CaptureCommandSchema.safeParse(body.command);
+  if (!command.success) {
+    return reply.code(400).send({ ok: false, error: 'command must be a supported capture command' });
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = validateCapturePayload(command.data, body.payload);
+  } catch (error) {
+    return reply.code(400).send({
+      ok: false,
+      error: error instanceof Error ? error.message : 'Invalid capture payload',
+    });
+  }
+
+  if (!wsManager) {
+    return reply.code(503).send({ ok: false, error: 'WebSocket manager unavailable' });
   }
 
   try {
     const result = await wsManager.sendCaptureCommand(
       body.sessionId,
-      body.command as Parameters<WebSocketManager['sendCaptureCommand']>[1],
-      body.payload && typeof body.payload === 'object' && !Array.isArray(body.payload) ? body.payload : {},
+      command.data,
+      payload,
       typeof body.timeoutMs === 'number' && Number.isFinite(body.timeoutMs) ? Math.floor(body.timeoutMs) : 4000,
     );
     return result;

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -285,6 +285,32 @@ no frame target is supplied. Passing `frameId` or `frameUrlContains` limits eith
 single frame. For `assert_page_state` and `wait_for_page_state`, `frameUrlContains` remains an item
 matcher over the aggregate page model.
 
+Single-frame DOM, style, layout, and targeted page-state responses include
+`resolvedFrame: { frameId, url }`. Untargeted page-state responses describe every contributing
+frame in `frames`.
+
+### Targeting capability matrix
+
+`✓` means supported. `—` means unsupported and rejected as an unknown payload key.
+
+| Raw command | `tabId` | `frameId` | `frameUrlContains` | Default scope |
+| --- | --- | --- | --- | --- |
+| `CAPTURE_DOM_SUBTREE` | ✓ | ✓ | ✓ | Top frame |
+| `CAPTURE_DOM_DOCUMENT` | ✓ | ✓ | ✓ | Top frame |
+| `CAPTURE_COMPUTED_STYLES` | ✓ | ✓ | ✓ | Top frame |
+| `CAPTURE_LAYOUT_METRICS` | ✓ | ✓ | ✓ | Top frame |
+| `CAPTURE_PAGE_STATE` | ✓ | ✓ | ✓ | All frames |
+| `CAPTURE_UI_SNAPSHOT`, `SET_VIEWPORT` | ✓ | — | — | Top frame |
+| `CAPTURE_GET_LIVE_CONSOLE_LOGS` | ✓ | — | — | Session buffer |
+| Navigation, dialog, stable-layout, and download waits | ✓ | — | — | Bound session tab |
+| `CAPTURE_WAIT_FOR_POPUP` | `openerTabId` | — | — | Bound opener tab |
+| Override observe, response-body, and enable commands | ✓ | — | — | Bound override tab |
+| Override status and disable commands | — | — | — | Active override |
+| `EXECUTE_UI_ACTION` | `target.tabId` | `target.frameId` | `target.frameUrlContains` | Bound session tab |
+
+The raw `/internal/capture-command` boundary is strict for every command: an unknown payload key
+returns HTTP 400 with the offending and accepted keys. No payload key is silently ignored.
+
 ### get_dom_subtree
 
 Captures a reduced DOM subtree for a selector.


### PR DESCRIPTION
Closes #37

## What changed
- reject unknown raw capture payload keys with HTTP 400 and accepted-key guidance
- include `resolvedFrame` on single-frame DOM, style, layout, and targeted page-state results
- document the targeting capability matrix

## Validation
- `pnpm verify:ci`
- `pnpm nx run e2e-playwright:smoke --skipNxCache` (3 passed)
- targeted frame-routing E2E (1 passed)
- full E2E: 37 passed; unrelated RSC fixture navigation flaked once and passed its immediate targeted rerun