### PR TITLE
fix(cli): make fallback setup and snapshot refusals actionable

### DIFF
--- a/.agents/skills/browser-debug-cli/SKILL.md
+++ b/.agents/skills/browser-debug-cli/SKILL.md
@@ -7,7 +7,22 @@ description: Use when MCP tools are unavailable or blocked but terminal commands
 
 Use `bdmcp` when Browser Debug MCP Bridge evidence is needed and MCP tools are not available.
 
-Start with:
+First verify that the packaged CLI is installed:
+
+```bash
+bdmcp --help
+```
+
+If the command is not found, install the package that provides it:
+
+```bash
+npm i -g browser-debug-mcp-bridge
+```
+
+From a local repo clone without a global install, use `node scripts/browser-debug-cli.cjs`
+in place of `bdmcp`.
+
+Then start with:
 
 ```bash
 bdmcp health

--- a/HOW_TO_USE_BROWSER_DEBUG_MCP_BRIDGE.md
+++ b/HOW_TO_USE_BROWSER_DEBUG_MCP_BRIDGE.md
@@ -99,11 +99,16 @@ Keep `-y` in `npx` MCP host configs. Without it, npm can wait for interactive in
 If Copilot MCP servers are disabled by organization policy but terminal commands are allowed, use the packaged CLI:
 
 ```bash
+bdmcp --help
 browser-debug-mcp-bridge --standalone
 bdmcp init-copilot
 bdmcp health
 bdmcp sessions --live
 ```
+
+The global `npm i -g browser-debug-mcp-bridge` install above provides `bdmcp`. If the check fails,
+rerun that install. A local clone does not add `bdmcp` to `PATH`; use
+`node scripts/browser-debug-cli.cjs` in place of `bdmcp`.
 
 ### 1B) Local clone mode
 
@@ -111,6 +116,13 @@ bdmcp sessions --live
 git clone https://github.com/<ORG_OR_USER>/browser-debug-mcp-bridge.git
 cd browser-debug-mcp-bridge
 pnpm install
+```
+
+Build and invoke the CLI from a clone without installing it globally:
+
+```bash
+pnpm build:mcp-runtime
+node scripts/browser-debug-cli.cjs health
 ```
 
 Important:

--- a/README.md
+++ b/README.md
@@ -103,12 +103,17 @@ Keep `-y` in `npx` configs. Without it, npm can wait for an interactive install 
 If a Copilot organization disables MCP servers but terminal commands are allowed, use the packaged CLI workflow instead:
 
 ```bash
+bdmcp --help
 browser-debug-mcp-bridge --standalone
 bdmcp init-copilot
 bdmcp health
 bdmcp sessions --live
 bdmcp summary @recommended
 ```
+
+The global `npm i -g browser-debug-mcp-bridge` install above provides both
+`browser-debug-mcp-bridge` and `bdmcp`. If `bdmcp --help` is not found, rerun that install.
+From a local clone, use `node scripts/browser-debug-cli.cjs` in place of `bdmcp`.
 
 The CLI exposes the same bridge tool handlers through local commands and a token-protected local gateway. See [Browser Debug CLI](docs/BROWSER_DEBUG_CLI.md).
 

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -9,9 +9,9 @@ import {
 import {
   applySafeModeRestrictions,
   canExecuteLiveAutomation,
-  canCaptureSnapshot,
   CaptureConfig,
   DEFAULT_CAPTURE_CONFIG,
+  getSnapshotCaptureBlockReason,
   isUrlAllowed,
   loadCaptureConfig,
   requiresSensitiveAutomationOptIn,
@@ -4623,8 +4623,18 @@ async function executeCaptureCommand(
 
   if (command === 'CAPTURE_UI_SNAPSHOT') {
     const llmRequested = payload.llmRequested === true;
-    if (!canCaptureSnapshot(captureConfig, { llmRequested })) {
-      throw new Error('Snapshot capture is disabled or requires request opt-in');
+    const blockReason = getSnapshotCaptureBlockReason(captureConfig, { llmRequested });
+    if (blockReason === 'snapshots_disabled') {
+      throw new Error(
+        'Snapshot capture is disabled in extension settings. Open the extension popup, enable '
+        + 'Capture Settings > Snapshot capture > Enable snapshots (manual), then save settings.',
+      );
+    }
+    if (blockReason === 'request_opt_in_required') {
+      throw new Error(
+        'Snapshot capture requires request opt-in. Set llmRequested: true in the CAPTURE_UI_SNAPSHOT '
+        + 'payload, or use capture_ui_snapshot/bdmcp snapshot, which opts in automatically.',
+      );
     }
 
     const trigger = normalizeSnapshotTrigger(payload.trigger);

--- a/apps/chrome-extension/src/capture-controls.spec.ts
+++ b/apps/chrome-extension/src/capture-controls.spec.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   applySafeModeRestrictions,
   canExecuteLiveAutomation,
-  canCaptureSnapshot,
   DEFAULT_CAPTURE_CONFIG,
+  getSnapshotCaptureBlockReason,
   isUrlAllowed,
   loadCaptureConfig,
   normalizeCaptureConfig,
@@ -223,9 +223,9 @@ describe('capture controls', () => {
     expect(standard.snapshots.privacy.profile).toBe('standard');
   });
 
-  it('enforces manual toggle and opt-in gate for snapshot capture', () => {
+  it('identifies the snapshot capture gate that blocked a request', () => {
     expect(
-      canCaptureSnapshot(
+      getSnapshotCaptureBlockReason(
         {
           ...DEFAULT_CAPTURE_CONFIG,
           snapshots: {
@@ -235,10 +235,10 @@ describe('capture controls', () => {
         },
         { llmRequested: true }
       )
-    ).toBe(false);
+    ).toBe('snapshots_disabled');
 
     expect(
-      canCaptureSnapshot(
+      getSnapshotCaptureBlockReason(
         {
           ...DEFAULT_CAPTURE_CONFIG,
           snapshots: {
@@ -249,10 +249,10 @@ describe('capture controls', () => {
         },
         { llmRequested: false }
       )
-    ).toBe(false);
+    ).toBe('request_opt_in_required');
 
     expect(
-      canCaptureSnapshot(
+      getSnapshotCaptureBlockReason(
         {
           ...DEFAULT_CAPTURE_CONFIG,
           snapshots: {
@@ -263,7 +263,7 @@ describe('capture controls', () => {
         },
         { llmRequested: false }
       )
-    ).toBe(true);
+    ).toBeUndefined();
   });
 
   it('keeps computed-full only when explicitly selected', () => {

--- a/apps/chrome-extension/src/capture-controls.ts
+++ b/apps/chrome-extension/src/capture-controls.ts
@@ -120,21 +120,21 @@ export function requiresSensitiveAutomationOptIn(target: {
   return target.action === 'input' && selector.length === 0;
 }
 
-export function canCaptureSnapshot(
+export function getSnapshotCaptureBlockReason(
   config: CaptureConfig,
   context: {
     llmRequested: boolean;
   }
-): boolean {
+): 'snapshots_disabled' | 'request_opt_in_required' | undefined {
   if (!config.snapshots.enabled) {
-    return false;
+    return 'snapshots_disabled';
   }
 
   if (config.snapshots.requireOptIn && !context.llmRequested) {
-    return false;
+    return 'request_opt_in_required';
   }
 
-  return true;
+  return undefined;
 }
 
 function normalizeSnapshotCaptureConfig(value: unknown): SnapshotCaptureConfig {

--- a/apps/docs/docs/getting-started/install-and-client-setup.md
+++ b/apps/docs/docs/getting-started/install-and-client-setup.md
@@ -12,6 +12,12 @@ Install runtime:
 npm i -g browser-debug-mcp-bridge
 ```
 
+This install provides both `browser-debug-mcp-bridge` and `bdmcp`. Verify the CLI before use:
+
+```bash
+bdmcp --help
+```
+
 Download extension asset `chrome-extension-dist.tgz` from latest release and load unpacked in Chrome:
 
 1. Open `chrome://extensions`
@@ -32,6 +38,13 @@ Configure MCP host with direct Node launch:
 git clone https://github.com/<ORG_OR_USER>/browser-debug-mcp-bridge.git
 cd browser-debug-mcp-bridge
 pnpm install
+```
+
+A clone is not added to `PATH`. Build and invoke its CLI directly:
+
+```bash
+pnpm build:mcp-runtime
+node scripts/browser-debug-cli.cjs health
 ```
 
 ## 3) Build extension and load in Chrome
@@ -74,6 +87,7 @@ GitHub fallback (if registry package is not available):
 If Copilot MCP servers are disabled by organization policy but terminal commands are allowed, use the packaged CLI workflow:
 
 ```bash
+bdmcp --help
 browser-debug-mcp-bridge --standalone
 bdmcp init-copilot
 bdmcp health

--- a/apps/docs/docs/troubleshooting/common-issues.md
+++ b/apps/docs/docs/troubleshooting/common-issues.md
@@ -53,6 +53,17 @@ Actions:
 - If using `npx`, keep `-y` in args, for example `["-y", "browser-debug-mcp-bridge"]`
 - Without `-y`, npm can wait for interactive install confirmation; VS Code Copilot and other MCP hosts cannot answer that prompt, so startup stalls before tools are registered
 
+## `bdmcp` command is not found
+
+- Install the package that provides it: `npm i -g browser-debug-mcp-bridge`
+- Verify with `bdmcp --help`
+- From a local clone, use `node scripts/browser-debug-cli.cjs` in place of `bdmcp`
+
+## Snapshot capture is refused
+
+- If the error says snapshots are disabled, open the extension popup and enable **Capture Settings > Snapshot capture > Enable snapshots (manual)**, then save settings
+- If the error says request opt-in is required, use the `capture_ui_snapshot` MCP tool or `bdmcp snapshot`; raw `CAPTURE_UI_SNAPSHOT` callers must set `llmRequested: true`
+
 ## MCP process remains alive after host closes
 
 - In `mcp-stdio` mode, process should stop when host transport closes

--- a/apps/mcp-server/src/cli/agent-instructions.ts
+++ b/apps/mcp-server/src/cli/agent-instructions.ts
@@ -9,7 +9,22 @@ applyTo: "**"
 
 When browser debugging evidence is needed and MCP tools are unavailable, use the packaged CLI instead of guessing from source alone.
 
-Start with:
+First verify that the packaged CLI is installed:
+
+\`\`\`bash
+bdmcp --help
+\`\`\`
+
+If the command is not found, install the package that provides it:
+
+\`\`\`bash
+npm i -g browser-debug-mcp-bridge
+\`\`\`
+
+From a local repo clone without a global install, use \`node scripts/browser-debug-cli.cjs\`
+in place of \`bdmcp\`.
+
+Then start with:
 
 \`\`\`bash
 bdmcp health
@@ -46,7 +61,22 @@ description: Use when MCP tools are unavailable or blocked but terminal commands
 
 Use \`bdmcp\` when Browser Debug MCP Bridge evidence is needed and MCP tools are not available.
 
-Start with:
+First verify that the packaged CLI is installed:
+
+\`\`\`bash
+bdmcp --help
+\`\`\`
+
+If the command is not found, install the package that provides it:
+
+\`\`\`bash
+npm i -g browser-debug-mcp-bridge
+\`\`\`
+
+From a local repo clone without a global install, use \`node scripts/browser-debug-cli.cjs\`
+in place of \`bdmcp\`.
+
+Then start with:
 
 \`\`\`bash
 bdmcp health

--- a/apps/mcp-server/src/cli/main.spec.ts
+++ b/apps/mcp-server/src/cli/main.spec.ts
@@ -2,9 +2,19 @@ import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { getSkillInstructions } from './agent-instructions';
 import { getBaseUrl, isLiveSession, parseArgs, parseJsonObject, parseToolArguments, withCommonLimits } from './main';
 
 describe('bdmcp CLI parsing', () => {
+  it('tells agents which package installs bdmcp before using it', () => {
+    const instructions = getSkillInstructions();
+
+    expect(instructions).toContain('bdmcp --help');
+    expect(instructions).toContain('npm i -g browser-debug-mcp-bridge');
+    expect(instructions.indexOf('npm i -g browser-debug-mcp-bridge')).toBeLessThan(instructions.indexOf('bdmcp health'));
+    expect(instructions).toContain('node scripts/browser-debug-cli.cjs');
+  });
+
   it('parses command words and long options', () => {
     const parsed = parseArgs(['tool', 'run', 'list_sessions', '--json-args', '{"limit":10}', '--json']);
 

--- a/docs/BROWSER_DEBUG_CLI.md
+++ b/docs/BROWSER_DEBUG_CLI.md
@@ -10,11 +10,24 @@ Use it when an AI environment cannot use MCP tools, for example when a Copilot o
 npm i -g browser-debug-mcp-bridge
 ```
 
+Verify the install before starting a debugging workflow:
+
+```bash
+bdmcp --help
+```
+
 The package provides these commands:
 
 - `browser-debug-mcp-bridge`: MCP stdio launcher
 - `bdmcp`: browser-debug CLI
 - `browser-debug-cli`: alias for `bdmcp`
+
+From a local repo clone, `pnpm install` does not add the project itself to `PATH`. Use:
+
+```bash
+pnpm build:mcp-runtime
+node scripts/browser-debug-cli.cjs health
+```
 
 Start the bridge in a terminal:
 
@@ -107,6 +120,22 @@ Example `browser-debug-args.json`:
   "limit": 10
 }
 ```
+
+## Direct HTTP fallback
+
+The loopback HTTP surface supports terminal or script clients even when MCP and `bdmcp` are
+unavailable:
+
+```bash
+curl http://127.0.0.1:8065/health
+curl http://127.0.0.1:8065/stats
+curl http://127.0.0.1:8065/cli/tools
+```
+
+Generic tool execution uses `POST /cli/tools/:toolName` and requires
+`x-browser-debug-cli-token`. The token is in `cli-token.json` under the runtime data directory
+(`DATA_DIR` when set, otherwise the platform app-data directory). Keep it local and do not paste
+it into logs or chat. The packaged CLI reads it automatically and is the preferred interface.
 
 ## Security
 


### PR DESCRIPTION
Closes #38

## What changed
- distinguish disabled snapshot capture from missing request opt-in and give exact remedies
- make generated and packaged bdmcp instructions verify or install the CLI before use
- document local-clone invocation and authenticated loopback HTTP fallback

## Validation
- pnpm verify:ci
- pnpm nx run e2e-playwright:smoke --skipNxCache (3 passed)
- pnpm nx run e2e-playwright:full --skipNxCache (38 passed)